### PR TITLE
feat: emit AiderTerminalOpen event when terminal is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ require("nvim_aider").setup({
 })
 ```
 
+## 🎮 Terminal Keymaps
+
+The plugin emits a `User` event `AiderTerminalOpen` when the terminal is created, allowing you to set up buffer-local keymaps. For example, to make `<Esc>` close the terminal in normal mode:
+
+```lua
+vim.api.nvim_create_autocmd("User", {
+  pattern = "AiderTerminalOpen",
+  callback = function(args)
+    local buf = args.data.buf
+    vim.keymap.set("n", "<Esc>", function()
+      require("nvim_aider.terminal").toggle()
+    end, { buffer = buf, silent = true })
+  end,
+})
+```
+
 ---
 
 <div align="center">

--- a/lua/nvim_aider/terminal.lua
+++ b/lua/nvim_aider/terminal.lua
@@ -29,7 +29,17 @@ function M.toggle(opts)
   opts = vim.tbl_deep_extend("force", config.options, opts or {})
 
   local cmd = create_cmd(opts)
-  return snacks.toggle(cmd, opts)
+  local term = snacks.toggle(cmd, opts)
+  
+  -- Emit event when terminal is created/toggled on
+  if term and term:buf_valid() then
+    vim.api.nvim_exec_autocmds("User", {
+      pattern = "AiderTerminalOpen",
+      data = { buf = term.buf }
+    })
+  end
+  
+  return term
 end
 
 ---Send text to terminal


### PR DESCRIPTION
Hi,

I was looking for a way to add shortcuts that are only applied to this specific buffer. I wanted to use escape to close in normal mode, and `<c-s>` in all modes, but only in the aider terminal buffer.  

Rather than fussing around with checking buffer names in an autocmd, I found it easier to just emit a User event in the plugin on my branch and use the following code in my LazyVim:
```lua
  {
   "GeorgesAlkhouri/nvim-aider",
   init = function()
     vim.api.nvim_create_autocmd("User", {
       pattern = "AiderTerminalOpen",
       callback = function(args)
         local buf = args.data.buf
         vim.keymap.set("n", "<Esc>", function()
           require("nvim_aider.terminal").toggle()
         end, { buffer = buf, silent = true })

         vim.keymap.set({"t", "n", "i", "v"}, "<c-s>", function()
           require("nvim_aider.terminal").toggle()
         end, { buffer = buf, silent = true })
       end,
     })
   end,
```

Not sure if you find this at all helpful, but if you do feel free to merge this (or supply any feedback and I'll happily make the change).  

This has been my favorite nvim aider plugin for its simplicity, and I'm happy to contribute more if you're supporting it.

This PR was written 100% by aider / claude sonnet, including the readme.  Keeping with the plugin theme, no code was written by a human, though this pr description is 100% me.