### PR TITLE
feat: add `AiderHealth` checkhealth command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 ## 🎮 Commands
 
+- 🩺 `AiderHealth` - Check if everything is working correctly
 - ⌨️ `AiderTerminalToggle` - Toggle the Aider terminal window
 - 📤 `AiderTerminalSend [text]` - Send text to Aider
   - Without arguments: Opens input prompt
@@ -51,7 +52,7 @@ Using lazy.nvim:
 {
     "GeorgesAlkhouri/nvim-aider",
     cmd = {
-      "AiderTerminalToggle",
+      "AiderTerminalToggle", "AiderHealth",
     },
     keys = {
       { "<leader>a/", "<cmd>AiderTerminalToggle<cr>", desc = "Open Aider" },

--- a/lua/nvim_aider/health.lua
+++ b/lua/nvim_aider/health.lua
@@ -62,6 +62,14 @@ function M.check()
   else
     health.info("catppuccin plugin not found (optional)")
   end
+
+  -- nvim-tree plugin check
+  local has_nvim_tree = pcall(require, "nvim-tree")
+  if has_nvim_tree then
+    health.ok("nvim-tree plugin found (optional)")
+  else
+    health.info("nvim-tree plugin not found (optional)")
+  end
 end
 
 return M

--- a/lua/nvim_aider/init.lua
+++ b/lua/nvim_aider/init.lua
@@ -23,6 +23,10 @@ end
 function M.setup(opts)
   M.config.setup(opts)
 
+  vim.api.nvim_create_user_command("AiderHealth", function()
+    vim.cmd([[checkhealth nvim_aider]])
+  end, { desc = "Run :checkhealth nvim_aider" })
+
   vim.api.nvim_create_user_command("AiderTerminalToggle", function()
     M.terminal.toggle()
   end, {})

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -25,6 +25,7 @@ require("lazy.minit").setup({
       "GeorgesAlkhouri/nvim-aider",
       cmd = {
         "AiderTerminalToggle",
+        "AiderHealth",
       },
       keys = {
         { "<leader>a/", "<cmd>AiderTerminalToggle<cr>", desc = "Open Aider" },

--- a/tests/nvim_aider_spec.lua
+++ b/tests/nvim_aider_spec.lua
@@ -25,6 +25,7 @@ describe("nvim_aider", function()
     -- Check that the user commands were created
     local user_commands = vim.api.nvim_get_commands({})
     local expected_commands = {
+      "AiderHealth",
       "AiderTerminalToggle",
       "AiderTerminalSend",
       "AiderQuickSendCommand",
@@ -38,6 +39,11 @@ describe("nvim_aider", function()
     for _, cmd in ipairs(expected_commands) do
       assert(user_commands[cmd], "Expected command '" .. cmd .. "' to be registered after setup()")
     end
+  end)
+
+  it("executes AiderHealth command without error", function()
+    local health_cmd_ok = pcall(vim.cmd, "AiderHealth")
+    assert(health_cmd_ok, "AiderHealth command should execute without error")
   end)
 
   describe("nvim-tree integration", function()


### PR DESCRIPTION
"AiderHealth" command for running built-in checkhealth under the "nvim_aider" section, ensuring all plugin dependencies are correctly configured.
