### PR TITLE
feat(config): support custom aider_cmd 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 <img width="1280" alt="screenshot_1" src="https://github.com/user-attachments/assets/5d779f73-5441-4d24-8cce-e6dfdc5bf787" />
 <img width="1280" alt="screenshot_2" src="https://github.com/user-attachments/assets/3c122846-ca27-42d3-8cbf-f6e5f9b10f69" />
 
-
 > 🚧 This plugin is in initial development. Expect breaking changes and rough edges.  
 > _October 17, 2024_
 
@@ -83,6 +82,8 @@ There is no need to call setup if you don't want to change the default options.
 
 ```lua
 require("nvim_aider").setup({
+  -- Command that executes Aider
+  aider_cmd = "aider",
   -- Command line arguments passed to aider
   args = {
     "--no-auto-commits",

--- a/devenv.lock
+++ b/devenv.lock
@@ -31,10 +31,46 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737465171,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -66,48 +102,101 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-devenv": {
       "locked": {
-        "lastModified": 1736042175,
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "bf689c40d035239a489de5997a4da5352434632e",
+        "lastModified": 1733477122,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
+    "nixpkgs-python": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
+        "flake-compat": "flake-compat_2",
         "nixpkgs": [
+          "noospherix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
+        "lastModified": 1733319315,
         "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "repo": "nixpkgs-python",
+        "rev": "01263eeb28c09f143d59cd6b0b7c4cc8478efd48",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1740367490,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1740463929,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "noospherix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-devenv": "nixpkgs-devenv",
+        "nixpkgs-python": "nixpkgs-python",
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      },
+      "locked": {
+        "lastModified": 1740299658,
+        "owner": "GeorgesAlkhouri",
+        "repo": "noospherix",
+        "rev": "7a684d91e8185bda3505a7219eadb6845b5d65fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "GeorgesAlkhouri",
+        "repo": "noospherix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "noospherix": "noospherix",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,7 +6,9 @@
   ...
 }:
 let
-  unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
+  unstable = import inputs.noospherix.inputsHub.nixpkgs-unstable {
+    system = pkgs.stdenv.system;
+  };
 in
 {
   packages = with unstable; [

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
-  nixpkgs-unstable:
-    url: github:nixos/nixpkgs/nixpkgs-unstable
-  nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
+  noospherix:
+    url: github:GeorgesAlkhouri/noospherix

--- a/lua/nvim_aider/config.lua
+++ b/lua/nvim_aider/config.lua
@@ -12,6 +12,7 @@
 ---@field completion_menu_current_bg_color nvim_aider.Color
 
 ---@class nvim_aider.Config: snacks.terminal.Opts
+---@field aider_cmd? string
 ---@field args? string[]
 ---@field theme? nvim_aider.Theme
 ---@field win? snacks.win.Config
@@ -19,6 +20,7 @@
 local M = {}
 
 M.defaults = {
+  aider_cmd = "aider",
   args = {
     "--no-auto-commits",
     "--pretty",

--- a/lua/nvim_aider/health.lua
+++ b/lua/nvim_aider/health.lua
@@ -3,25 +3,18 @@ local health = vim.health or require("health")
 
 function M.check()
   health.start("Plugin Dependencies")
-
-  -- Check aider executable
-  local aider_exists = vim.fn.executable("aider") == 1
-  if aider_exists then
-    local version_output = vim.fn.system("aider --version")
-    if version_output then
-      local version = vim.version.parse(version_output)
-      if version then
-        health.ok(string.format("aider v%d.%d.%d found", version.major, version.minor, version.patch))
-      else
-        health.error("Failed to parse aider version")
-      end
+  local options = require("nvim_aider.config").options
+  -- Check aider is executable
+  local version_output = vim.fn.systemlist(options.aider_cmd .. " --version")
+  if version_output and vim.v.shell_error == 0 then
+    local version = vim.version.parse(version_output[#version_output])
+    if version then
+      health.ok(string.format("aider v%d.%d.%d found", version.major, version.minor, version.patch))
     else
-      health.error("Could not determine aider version")
+      health.error("Failed to parse aider version")
     end
   else
-    health.error("aider executable not found in PATH", {
-      "Install with: python -m pip install -U aider-chat",
-    })
+    health.error("Could not determine aider version")
   end
 
   -- Snacks plugin check

--- a/lua/nvim_aider/terminal.lua
+++ b/lua/nvim_aider/terminal.lua
@@ -2,31 +2,25 @@ local M = {}
 
 local config = require("nvim_aider.config")
 
----Create command string list from options
 ---@param opts nvim_aider.Config
----@return string[]
+---@return string
 local function create_cmd(opts)
-  local cmd = { "aider" }
+  local cmd = { opts.aider_cmd }
   vim.list_extend(cmd, opts.args or {})
 
   if opts.theme then
     for key, value in pairs(opts.theme) do
-      table.insert(cmd, "--" .. key:gsub("_", "-"))
-      table.insert(cmd, value)
+      table.insert(cmd, "--" .. key:gsub("_", "-") .. "=" .. tostring(value))
     end
   end
 
-  return cmd
+  return table.concat(cmd, " ")
 end
 
 ---Toggle terminal visibility
 ---@param opts? nvim_aider.Config
 ---@return snacks.win?
 function M.toggle(opts)
-  if vim.fn.executable("aider") == 0 then
-    vim.notify("aider executable not found in PATH", vim.log.levels.ERROR)
-    return
-  end
   local snacks = require("snacks.terminal")
 
   opts = vim.tbl_deep_extend("force", config.options, opts or {})
@@ -40,11 +34,6 @@ end
 ---@param opts? nvim_aider.Config
 ---@param multi_line? boolean
 function M.send(text, opts, multi_line)
-  if vim.fn.executable("aider") == 0 then
-    vim.notify("aider executable not found in PATH", vim.log.levels.ERROR)
-    return
-  end
-
   multi_line = multi_line == nil and true or multi_line
   opts = vim.tbl_deep_extend("force", config.options, opts or {})
 


### PR DESCRIPTION
✨ Allow custom aider_cmd in config instead of hardcoding "aider". 🔧 Format theme flags as "--key=value" for better argument support. 🔍 Update health check to use the configured aider_cmd.