### PR TITLE
fix(adding file): prevent new terminal due to duplicate opts

### DIFF
--- a/lua/nvim_aider/terminal.lua
+++ b/lua/nvim_aider/terminal.lua
@@ -72,7 +72,6 @@ end
 function M.command(command, text, opts)
   text = text or ""
 
-  opts = vim.tbl_deep_extend("force", config.options, opts or {})
   -- NOTE: For Aider commands that shouldn't get a newline (e.g. `/add file`)
   M.send(command .. " " .. text, opts, false)
 end


### PR DESCRIPTION
I noticed that when using `:Aider toggle` the terminal (Terminal 1) would open as expected. But then, when using `:Aider add` it would open a new terminal (Terminal 2). Which is annoying, because `:Aider toggle` would then only toggle Terminal 1. And Terminal 2 needs to be closed manually.

The reason seems to be that `opts` get extended both in `M.command` and then in `M.send`.
which triggers 
` local term = require("snacks.terminal").get(cmd, opts)` to create a new terminal. 

I assume this is not intended behaviour
