### PR TITLE
Feat/allowtelescope v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ luac.out
 *.hex
 .aider*
 .env
+memory-bank/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - [x] ♻️ Reset command to clear session
 - [x] 💬 Optional user prompt for buffer and selection sends
 - [x] 🩺 Send current buffer diagnostics to Aider
-- [x] 🔍 Aider command selection UI with fuzzy search and input prompt
+- [x] 🔍 Aider command selection UI with fuzzy search and input prompt (supports [Telescope](https://github.com/nvim-telescope/telescope.nvim))
 - [x] 🔌 Fully documented [Lua API](lua/nvim_aider/api.lua) for
       programmatic interaction and custom integrations
 - [x] 🌲➕ [Neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
@@ -26,6 +26,7 @@
 - [x] 🌳 Integration with [nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua)
       for adding or dropping files directly from the tree interface
 - [x] 🔄 Auto-reload buffers on external changes (requires 'autoread')
+- [x] 🖥️ Support for Neovim's built-in terminal or Snacks terminal
 
 ## 🎮 Commands
 
@@ -58,8 +59,8 @@
 
 🐍 Python: Install `aider-chat`
 📋 System: **Neovim** >= 0.9.4, ~~Working clipboard~~ thanks to @milanglacier
-🌙 Lua: `folke/snacks.nvim`,
-_optionals_ `catppuccin/nvim`, `nvim-neo-tree/neo-tree.nvim`, `nvim-tree.lua`
+🌙 Lua:
+_optionals_ `folke/snacks.nvim`, `catppuccin/nvim`, `nvim-neo-tree/neo-tree.nvim`, `nvim-tree.lua`, `nvim-telescope/telescope.nvim` (if using telescope picker)
 
 ## 📦 Installation
 
@@ -84,8 +85,8 @@ Using lazy.nvim:
       { "<leader>a-", "<cmd>AiderTreeDropFile<cr>", desc = "Drop File from Tree from Aider", ft = "NvimTree" },
     },
     dependencies = {
-      "folke/snacks.nvim",
       --- The below dependencies are optional
+      "folke/snacks.nvim", -- must set picker and terminal_emulator if not using snacks
       "catppuccin/nvim",
       "nvim-tree/nvim-tree.lua",
       --- Neo-tree integration
@@ -152,6 +153,10 @@ require("nvim_aider").setup({
     style = "nvim_aider",
     position = "right",
   },
+  -- Choose between 'snacks' (default) or 'telescope' for the picker UI
+  picker = "snacks",
+  -- Choose between 'snacks' (default) or 'nvim' for the Aider terminal window
+  terminal_emulator = "snacks",
 })
 ```
 

--- a/lua/nvim_aider/api.lua
+++ b/lua/nvim_aider/api.lua
@@ -162,22 +162,12 @@ function M.reset_session(opts)
   terminal.command(commands.reset.value, nil, opts or {})
 end
 
----Open command picker
+---Open slash command picker
 ---@param opts? table Optional configuration override
 ---@param callback? function Custom callback handler
 function M.open_command_picker(opts, callback)
-  picker.create(opts, callback or function(picker_instance, item)
-    if item.category == "input" then
-      vim.ui.input({ prompt = "Enter input for `" .. item.text .. "` (empty to skip):" }, function(input)
-        if input then
-          terminal.command(item.text, input, opts)
-        end
-      end)
-    else
-      terminal.command(item.text, nil, opts)
-    end
-    picker_instance:close()
-  end)
+  -- Delegate to the dedicated slash command picker function in picker.lua
+  require("nvim_aider.picker").open_slash_command_picker(opts, callback)
 end
 
 return M

--- a/lua/nvim_aider/commands_menu.lua
+++ b/lua/nvim_aider/commands_menu.lua
@@ -172,7 +172,7 @@ function M._menu()
     -- No need to explicitly close here for Telescope, it's done in create_generic's attach_mappings
     -- For snacks, create_generic passes the picker_instance to this callback, so we close it here.
     if config.picker == "snacks" and picker_instance and picker_instance.close then
-        picker_instance:close()
+      picker_instance:close()
     end
   end
 

--- a/lua/nvim_aider/config.lua
+++ b/lua/nvim_aider/config.lua
@@ -18,14 +18,14 @@
 ---@field theme? nvim_aider.Theme
 ---@field win? snacks.win.Config
 ---@field picker_cfg? snacks.picker.layout.Config
----@field picker? 'snacks' | 'telescope'
----@field terminal_emulator? 'snacks' | 'nvim' Choose between snacks.nvim or Neovim's built-in terminal
+---@field picker? 'snacks' | 'telescope' Picker implementation to use ('snacks' or 'telescope')
+---@field terminal_emulator? 'snacks' | 'nvim' Terminal emulator to use ('snacks' or 'nvim')
 local M = {}
 
 M.defaults = {
   auto_reload = false,
   aider_cmd = "aider",
-  terminal_emulator = "snacks", -- Default to snacks for backward compatibility
+  terminal_emulator = "snacks",
   args = {
     "--no-auto-commits",
     "--pretty",

--- a/lua/nvim_aider/config.lua
+++ b/lua/nvim_aider/config.lua
@@ -19,11 +19,13 @@
 ---@field win? snacks.win.Config
 ---@field picker_cfg? snacks.picker.layout.Config
 ---@field picker? 'snacks' | 'telescope'
+---@field terminal_emulator? 'snacks' | 'nvim' Choose between snacks.nvim or Neovim's built-in terminal
 local M = {}
 
 M.defaults = {
   auto_reload = false,
   aider_cmd = "aider",
+  terminal_emulator = "snacks", -- Default to snacks for backward compatibility
   args = {
     "--no-auto-commits",
     "--pretty",
@@ -101,7 +103,9 @@ function M.setup(opts)
   end
 
   M.options = vim.tbl_deep_extend("force", M.options, opts or {})
-  Snacks.config.style("nvim_aider", {})
+  if M.options.terminal_emulator == "snacks" then
+    Snacks.config.style("nvim_aider", {})
+  end
   return M.options
 end
 

--- a/lua/nvim_aider/config.lua
+++ b/lua/nvim_aider/config.lua
@@ -18,6 +18,7 @@
 ---@field theme? nvim_aider.Theme
 ---@field win? snacks.win.Config
 ---@field picker_cfg? snacks.picker.layout.Config
+---@field picker? 'snacks' | 'telescope'
 local M = {}
 
 M.defaults = {
@@ -52,6 +53,7 @@ M.defaults = {
   picker_cfg = {
     preset = "vscode",
   },
+  picker = "snacks",
 }
 
 ---@type nvim_aider.Config

--- a/lua/nvim_aider/picker.lua
+++ b/lua/nvim_aider/picker.lua
@@ -2,38 +2,114 @@
 local M = {}
 local config = require("nvim_aider.config")
 
----Create a picker for Aider commands
+---Create a generic picker
+---@param items table The list of items to display in the picker
+---@param longest_text_len number The length of the longest item text for formatting
 ---@param opts? nvim_aider.Config Optional config that will override the base config for this call only
----@param confirm? fun(picker: snacks.Picker, item: table) Callback function when an item is selected
-function M.create(opts, confirm)
+---@param confirm? fun(picker: any, item: table) Callback function when an item is selected (any because it could be snacks or telescope picker)
+function M.create_generic(items, longest_text_len, opts, confirm)
   opts = vim.tbl_deep_extend("force", config.options, opts or {})
-  -- Build items from commands
-  local items = {}
-  local longest_cmd = 0
-  for cmd_name, cmd_data in pairs(require("nvim_aider.commands_slash")) do
-    table.insert(items, {
-      text = cmd_data.value,
-      description = cmd_data.description,
-      category = cmd_data.category,
-      name = cmd_name,
+
+  if opts.picker == "telescope" then
+    local pickers = require("telescope.pickers")
+    local finders = require("telescope.finders")
+    local actions = require("telescope.actions")
+    local action_state = require("telescope.actions.state")
+    local conf = require("telescope.config").values
+
+    return pickers.new(opts, {
+      prompt_title = "Aider Picker", -- Generic title
+      finder = finders.new_table {
+        results = items,
+        entry_maker = function(entry)
+          -- Assuming items have 'text' and 'description' fields
+          local display_text = entry.text
+          -- Adjust display for subcommands if needed, similar to snacks format
+          if entry.parent then
+             display_text = " > " .. display_text:sub(#entry.parent + 2)
+          end
+          return {
+            value = entry, -- Store the original item data
+            display = string.format("%-" .. longest_text_len .. "s %s", display_text, entry.description or ""), -- Use description if available
+            ordinal = entry.text, -- Use item text for sorting
+          }
+        end,
+      },
+      sorter = conf.generic_sorter(opts),
+      attach_mappings = function(prompt_bufnr, map)
+        actions.select_default:replace(function()
+          actions.close(prompt_bufnr)
+          local selection = action_state.get_selected_entry()
+          if confirm then
+            -- Pass the original item data to the confirm callback
+            -- Pass nil for picker_instance as Telescope closing is handled by actions.close
+            confirm(nil, selection.value)
+          end
+        end)
+        return true
+      end,
+    }):find()
+  else -- Default to snacks
+    return require("snacks.picker")({
+      items = items,
+      layout = opts.picker_cfg,
+      format = function(item)
+        local ret = {}
+        local display_text = item.text
+        if item.parent then
+          display_text = " > " .. display_text:sub(#item.parent + 2)
+        end
+        ret[#ret + 1] = { ("%-" .. longest_text_len .. "s"):format(display_text), "Function" }
+        ret[#ret + 1] = { " " .. (item.description or ""), "Comment" } -- Use description if available
+        return ret
+      end,
+      prompt = "Aider Picker > ", -- Generic prompt
+      confirm = confirm,
     })
-    longest_cmd = math.max(longest_cmd, #cmd_data.value)
   end
-  longest_cmd = longest_cmd + 2
-
-  return require("snacks.picker")({
-    items = items,
-    layout = opts.picker_cfg,
-    format = function(item)
-      local ret = {}
-      ret[#ret + 1] = { ("%-" .. longest_cmd .. "s"):format(item.text), "Function" }
-      ret[#ret + 1] = { " " .. item.description, "Comment" }
-      return ret
-    end,
-
-    confirm = confirm,
-    prompt = "Aider \\ Commands > ",
-  })
 end
+
+---Create and open the slash command picker
+---@param opts? nvim_aider.Config Optional config that will override the base config for this call only
+---@param callback? fun(picker: any, item: table) Custom callback handler
+function M.open_slash_command_picker(opts, callback)
+    local commands_slash = require("nvim_aider.commands_slash")
+    local items = {}
+    local longest_cmd = 0
+    for cmd_name, cmd_data in pairs(commands_slash) do
+      table.insert(items, {
+        text = cmd_data.value,
+        description = cmd_data.description,
+        category = cmd_data.category,
+        name = cmd_name,
+        cmd_data = cmd_data, -- Store original data
+      })
+      longest_cmd = math.max(longest_cmd, #cmd_data.value)
+    end
+    longest_cmd = longest_cmd + 2
+
+    local confirm_callback = callback or function(picker_instance, item)
+      local terminal = require("nvim_aider.terminal") -- Require here to avoid circular dependency
+      local api = require("nvim_aider.api") -- Require here to avoid circular dependency
+
+      if item.category == "input" then
+        vim.ui.input({ prompt = "Enter input for `" .. item.text .. "` (empty to skip):" }, function(input)
+          if input then
+            terminal.command(item.text, input, opts)
+          end
+        end)
+      else
+        terminal.command(item.text, nil, opts)
+      end
+      -- For snacks, picker_instance is provided and needs closing.
+      -- For Telescope, picker_instance is nil, and closing is handled by actions.close in create_generic's attach_mappings.
+      if picker_instance and picker_instance.close then
+          picker_instance:close()
+      end
+    end
+
+    return M.create_generic(items, longest_cmd, opts, confirm_callback)
+end
+
 
 return M

--- a/lua/nvim_aider/picker.lua
+++ b/lua/nvim_aider/picker.lua
@@ -17,38 +17,40 @@ function M.create_generic(items, longest_text_len, opts, confirm)
     local action_state = require("telescope.actions.state")
     local conf = require("telescope.config").values
 
-    return pickers.new(opts, {
-      prompt_title = "Aider Picker", -- Generic title
-      finder = finders.new_table {
-        results = items,
-        entry_maker = function(entry)
-          -- Assuming items have 'text' and 'description' fields
-          local display_text = entry.text
-          -- Adjust display for subcommands if needed, similar to snacks format
-          if entry.parent then
-             display_text = " > " .. display_text:sub(#entry.parent + 2)
-          end
-          return {
-            value = entry, -- Store the original item data
-            display = string.format("%-" .. longest_text_len .. "s %s", display_text, entry.description or ""), -- Use description if available
-            ordinal = entry.text, -- Use item text for sorting
-          }
+    return pickers
+      .new(opts, {
+        prompt_title = "Aider Picker", -- Generic title
+        finder = finders.new_table({
+          results = items,
+          entry_maker = function(entry)
+            -- Assuming items have 'text' and 'description' fields
+            local display_text = entry.text
+            -- Adjust display for subcommands if needed, similar to snacks format
+            if entry.parent then
+              display_text = " > " .. display_text:sub(#entry.parent + 2)
+            end
+            return {
+              value = entry, -- Store the original item data
+              display = string.format("%-" .. longest_text_len .. "s %s", display_text, entry.description or ""), -- Use description if available
+              ordinal = entry.text, -- Use item text for sorting
+            }
+          end,
+        }),
+        sorter = conf.generic_sorter(opts),
+        attach_mappings = function(prompt_bufnr, map)
+          actions.select_default:replace(function()
+            actions.close(prompt_bufnr)
+            local selection = action_state.get_selected_entry()
+            if confirm then
+              -- Pass the original item data to the confirm callback
+              -- Pass nil for picker_instance as Telescope closing is handled by actions.close
+              confirm(nil, selection.value)
+            end
+          end)
+          return true
         end,
-      },
-      sorter = conf.generic_sorter(opts),
-      attach_mappings = function(prompt_bufnr, map)
-        actions.select_default:replace(function()
-          actions.close(prompt_bufnr)
-          local selection = action_state.get_selected_entry()
-          if confirm then
-            -- Pass the original item data to the confirm callback
-            -- Pass nil for picker_instance as Telescope closing is handled by actions.close
-            confirm(nil, selection.value)
-          end
-        end)
-        return true
-      end,
-    }):find()
+      })
+      :find()
   else -- Default to snacks
     return require("snacks.picker")({
       items = items,
@@ -73,22 +75,23 @@ end
 ---@param opts? nvim_aider.Config Optional config that will override the base config for this call only
 ---@param callback? fun(picker: any, item: table) Custom callback handler
 function M.open_slash_command_picker(opts, callback)
-    local commands_slash = require("nvim_aider.commands_slash")
-    local items = {}
-    local longest_cmd = 0
-    for cmd_name, cmd_data in pairs(commands_slash) do
-      table.insert(items, {
-        text = cmd_data.value,
-        description = cmd_data.description,
-        category = cmd_data.category,
-        name = cmd_name,
-        cmd_data = cmd_data, -- Store original data
-      })
-      longest_cmd = math.max(longest_cmd, #cmd_data.value)
-    end
-    longest_cmd = longest_cmd + 2
+  local commands_slash = require("nvim_aider.commands_slash")
+  local items = {}
+  local longest_cmd = 0
+  for cmd_name, cmd_data in pairs(commands_slash) do
+    table.insert(items, {
+      text = cmd_data.value,
+      description = cmd_data.description,
+      category = cmd_data.category,
+      name = cmd_name,
+      cmd_data = cmd_data, -- Store original data
+    })
+    longest_cmd = math.max(longest_cmd, #cmd_data.value)
+  end
+  longest_cmd = longest_cmd + 2
 
-    local confirm_callback = callback or function(picker_instance, item)
+  local confirm_callback = callback
+    or function(picker_instance, item)
       local terminal = require("nvim_aider.terminal") -- Require here to avoid circular dependency
       local api = require("nvim_aider.api") -- Require here to avoid circular dependency
 
@@ -104,12 +107,11 @@ function M.open_slash_command_picker(opts, callback)
       -- For snacks, picker_instance is provided and needs closing.
       -- For Telescope, picker_instance is nil, and closing is handled by actions.close in create_generic's attach_mappings.
       if picker_instance and picker_instance.close then
-          picker_instance:close()
+        picker_instance:close()
       end
     end
 
-    return M.create_generic(items, longest_cmd, opts, confirm_callback)
+  return M.create_generic(items, longest_cmd, opts, confirm_callback)
 end
-
 
 return M

--- a/lua/nvim_aider/terminal.lua
+++ b/lua/nvim_aider/terminal.lua
@@ -2,6 +2,13 @@ local M = {}
 
 local config = require("nvim_aider.config")
 
+-- Terminal state (for nvim term)
+local state = {
+  buf = nil,  -- Terminal buffer
+  win = nil,  -- Terminal window
+  chan = nil, -- Terminal channel ID
+}
+
 ---@param opts nvim_aider.Config
 ---@return string
 local function create_cmd(opts)
@@ -17,16 +24,69 @@ local function create_cmd(opts)
   return table.concat(cmd, " ")
 end
 
+-- Create a new Neovim terminal
+local function create_nvim_terminal(cmd, opts)
+  -- Create a vertical split
+  vim.cmd('vsplit')
+  local win = vim.api.nvim_get_current_win()
+  local buf = vim.api.nvim_create_buf(false, true)
+  
+  -- Set buffer options for persistence
+  vim.api.nvim_buf_set_option(buf, 'bufhidden', 'hide')
+  
+  -- Set the buffer in the window
+  vim.api.nvim_win_set_buf(win, buf)
+
+  -- Start terminal with the command
+  vim.fn.termopen(cmd, {
+    on_exit = function()
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+      state.buf = nil
+      state.win = nil
+      state.chan = nil
+    end
+  })
+  
+  -- Store state
+  state.buf = buf
+  state.win = win
+  state.chan = vim.api.nvim_buf_get_var(buf, "terminal_job_id")
+
+  -- Enter insert mode
+  vim.cmd('startinsert')
+  
+  return { buf = buf, win = win }
+end
+
 ---Toggle terminal visibility
 ---@param opts? nvim_aider.Config Optional config that will override the base config for this call only
 ---@return snacks.win?
 function M.toggle(opts)
-  local snacks = require("snacks.terminal")
-
   opts = vim.tbl_deep_extend("force", config.options, opts or {})
-
   local cmd = create_cmd(opts)
-  return snacks.toggle(cmd, opts)
+
+  if opts.terminal_emulator == "snacks" then
+    local snacks = require("snacks.terminal")
+    return snacks.toggle(cmd, opts)
+  else
+    -- Handle native terminal toggle
+    if state.win and vim.api.nvim_win_is_valid(state.win) then
+      -- Terminal window exists, hide it
+      vim.api.nvim_win_hide(state.win)
+    elseif state.buf and vim.api.nvim_buf_is_valid(state.buf) then
+      -- Buffer exists but not shown, show it in a new window
+      vim.cmd('vsplit')
+      local win = vim.api.nvim_get_current_win()
+      vim.api.nvim_win_set_buf(win, state.buf)
+      state.win = win
+      vim.cmd('startinsert')
+    else
+      -- Create new terminal
+      return create_nvim_terminal(cmd, opts)
+    end
+  end
 end
 
 ---Send text to terminal
@@ -37,31 +97,47 @@ function M.send(text, opts, multi_line)
   multi_line = multi_line == nil and true or multi_line
   opts = vim.tbl_deep_extend("force", config.options, opts or {})
 
-  local cmd = create_cmd(opts)
-  local term = require("snacks.terminal").get(cmd, opts)
-  if not term then
-    vim.notify("Please open an Aider terminal first.", vim.log.levels.INFO)
-    return
-  end
+  if opts.terminal_emulator == "snacks" then
+    -- Use existing snacks implementation
+    local cmd = create_cmd(opts)
+    local term = require("snacks.terminal").get(cmd, opts)
+    if not term then
+      vim.notify("Please open an Aider terminal first.", vim.log.levels.INFO)
+      return
+    end
 
-  if term and term:buf_valid() then
-    local chan = vim.api.nvim_buf_get_var(term.buf, "terminal_job_id")
-    if chan then
-      if multi_line then
-        -- Use bracketed paste sequences
-        local bracket_start = "\27[200~"
-        local bracket_end = "\27[201~\r"
-        local bracketed_text = bracket_start .. text .. bracket_end
-        vim.api.nvim_chan_send(chan, bracketed_text)
+    if term and term:buf_valid() then
+      local chan = vim.api.nvim_buf_get_var(term.buf, "terminal_job_id")
+      if chan then
+        if multi_line then
+          local bracket_start = "\27[200~"
+          local bracket_end = "\27[201~\r"
+          local bracketed_text = bracket_start .. text .. bracket_end
+          vim.api.nvim_chan_send(chan, bracketed_text)
+        else
+          text = text:gsub("\n", " ") .. "\n"
+          vim.api.nvim_chan_send(chan, text)
+        end
       else
-        text = text:gsub("\n", " ") .. "\n"
-        vim.api.nvim_chan_send(chan, text)
+        vim.notify("No Aider terminal job found!", vim.log.levels.ERROR)
       end
-    else
-      vim.notify("No Aider terminal job found!", vim.log.levels.ERROR)
     end
   else
-    vim.notify("Please open an Aider terminal first.", vim.log.levels.INFO)
+    -- Use native terminal implementation
+    if not state.chan then
+      vim.notify("Please open an Aider terminal first.", vim.log.levels.INFO)
+      return
+    end
+
+    if multi_line then
+      local bracket_start = "\27[200~"
+      local bracket_end = "\27[201~\r"
+      local bracketed_text = bracket_start .. text .. bracket_end
+      vim.api.nvim_chan_send(state.chan, bracketed_text)
+    else
+      text = text:gsub("\n", " ") .. "\n"
+      vim.api.nvim_chan_send(state.chan, text)
+    end
   end
 end
 

--- a/lua/nvim_aider/terminal.lua
+++ b/lua/nvim_aider/terminal.lua
@@ -4,8 +4,8 @@ local config = require("nvim_aider.config")
 
 -- Terminal state (for nvim term)
 local state = {
-  buf = nil,  -- Terminal buffer
-  win = nil,  -- Terminal window
+  buf = nil, -- Terminal buffer
+  win = nil, -- Terminal window
   chan = nil, -- Terminal channel ID
 }
 
@@ -27,13 +27,13 @@ end
 -- Create a new Neovim terminal
 local function create_nvim_terminal(cmd, opts)
   -- Create a vertical split
-  vim.cmd('vsplit')
+  vim.cmd("vsplit")
   local win = vim.api.nvim_get_current_win()
   local buf = vim.api.nvim_create_buf(false, true)
-  
+
   -- Set buffer options for persistence
-  vim.api.nvim_buf_set_option(buf, 'bufhidden', 'hide')
-  
+  vim.api.nvim_buf_set_option(buf, "bufhidden", "hide")
+
   -- Set the buffer in the window
   vim.api.nvim_win_set_buf(win, buf)
 
@@ -46,17 +46,17 @@ local function create_nvim_terminal(cmd, opts)
       state.buf = nil
       state.win = nil
       state.chan = nil
-    end
+    end,
   })
-  
+
   -- Store state
   state.buf = buf
   state.win = win
   state.chan = vim.api.nvim_buf_get_var(buf, "terminal_job_id")
 
   -- Enter insert mode
-  vim.cmd('startinsert')
-  
+  vim.cmd("startinsert")
+
   return { buf = buf, win = win }
 end
 
@@ -77,11 +77,11 @@ function M.toggle(opts)
       vim.api.nvim_win_hide(state.win)
     elseif state.buf and vim.api.nvim_buf_is_valid(state.buf) then
       -- Buffer exists but not shown, show it in a new window
-      vim.cmd('vsplit')
+      vim.cmd("vsplit")
       local win = vim.api.nvim_get_current_win()
       vim.api.nvim_win_set_buf(win, state.buf)
       state.win = win
-      vim.cmd('startinsert')
+      vim.cmd("startinsert")
     else
       -- Create new terminal
       return create_nvim_terminal(cmd, opts)


### PR DESCRIPTION
i dont use snacks in my neovim config and noticed there were others like me in the issues page (#64 #33). thought this would be a great learning experience for me to pick up and contribute. not that good with lua or neovim so let me know if theres something that needs work.

would love to have it pulled tho. i use this plugin a lot. thx for making it!

feat: Add configurable picker UI and native Neovim terminal support

This pull request introduces two new configuration options to `nvim-aider`: `picker` and `terminal_emulator`.

The `picker` option allows users to select their preferred UI for the file picker used in commands like `:AiderAdd`. Users can now choose between the existing 'snacks' picker and 'telescope.nvim' if they have it installed.

The `terminal_emulator` option allows users to choose which terminal window is used to display the Aider session. Previously, only `snacks.nvim` was supported. Now, users can opt to use the native Neovim terminal, which provides better integration with standard Neovim workflows. The native terminal window can be toggled visible or hidden.

These changes provide users with more flexibility in configuring `nvim-aider` to fit their existing Neovim setup and preferences.

**Key Changes:**

*   Add `picker` configuration option to select between 'snacks' and 'telescope'.
*   Add `terminal_emulator` configuration option to select between 'snacks.terminal' and 'nvim_terminal'.
*   Implement logic to use the selected picker UI.
*   Implement logic to use the selected terminal emulator, including toggling the native Neovim terminal window.
*   Update README to reflect new configuration options and features.

**Related Commits:**

*   8d29619 - docs: update README to reflect new telescope and native nvim term support
*   a9b0681 - feat: Add native nvim terminal support
*   c15dd2d - feat: Allow user to select between snacks and telescope for picker UI
